### PR TITLE
Remove replace on stringlist formatting

### DIFF
--- a/packer/config/consul/consul_client.json
+++ b/packer/config/consul/consul_client.json
@@ -9,6 +9,5 @@
   "atlas_token": "{{ atlas_token }}",
   "datacenter": "{{ datacenter }}",
   "node_name": "{{ node_name }}",
-  "skip_leave_on_interrupt": true,
-  "leave_on_terminate": true
+  "skip_leave_on_interrupt": true
 }

--- a/packer/config/consul/consul_server.json
+++ b/packer/config/consul/consul_server.json
@@ -11,6 +11,5 @@
   "bootstrap_expect": {{ consul_server_count }},
   "datacenter": "{{ datacenter }}",
   "node_name": "{{ node_name }}",
-  "skip_leave_on_interrupt": true,
-  "leave_on_terminate": true
+  "skip_leave_on_interrupt": true
 }

--- a/terraform/providers/aws/global/main.tf
+++ b/terraform/providers/aws/global/main.tf
@@ -76,16 +76,19 @@ module "staging_website" {
 output "admin_iam_config" {
   value = <<IAMCONFIG
 
-  Admins: ${replace(formatlist("%s\n          ", aws_iam_access_key.admins.*.user), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  Access Key IDs: ${replace(formatlist("%s\n                  ", aws_iam_access_key.admins.*.id), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  Secret Access Keys: ${replace(formatlist("%s\n                      ", aws_iam_access_key.admins.*.secret), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  Admins: ${join("\n          ", formatlist("%s", aws_iam_access_key.admins.*.user))}
+
+  Access IDs: ${join("\n              ", formatlist("%s", aws_iam_access_key.admins.*.id))}
+
+  Secret Keys: ${join("\n               ", formatlist("%s", aws_iam_access_key.admins.*.secret))}
 IAMCONFIG
 }
 
-output "nameserver_config_r53" {
+output "nameserver_config" {
   value = <<NAMESERVERCONFIG
+
 DNS records have been set in Route53, add NS records for ${var.domain} pointing to:
-  ${replace(formatlist("%s\n  ", split(",", aws_route53_zone.zone.*.name_servers)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  ${join("\n  ", formatlist("%s", aws_route53_zone.zone.*.name_servers))}
 NAMESERVERCONFIG
 }
 

--- a/terraform/providers/aws/us_east_1_prod/main.tf
+++ b/terraform/providers/aws/us_east_1_prod/main.tf
@@ -245,15 +245,19 @@ Visit the Node.js website:
            ${module.compute.nodejs_elb_dns}
 
   HAProxy: ${module.compute.haproxy_public_fqdn}
-           ${replace(formatlist("http://%s/\n           ", split(",", module.compute.haproxy_public_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+           ${join("\n           ", formatlist("http://%s/", split(",", module.compute.haproxy_public_ips)))}
+
 Add your private key and SSH into any private node via the Bastion host:
   ssh-add ../../../modules/keys/demo.pem
   ssh -A ${module.network.bastion_user}@${module.network.bastion_public_ip}
 
 Private node IPs:
-  Consul: ${replace(formatlist("ssh ubuntu@%s\n          ", split(",", module.data.consul_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  Vault: ${replace(formatlist("ssh ubuntu@%s\n         ", split(",", module.data.vault_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  HAProxy: ${replace(formatlist("ssh ubuntu@%s\n           ", split(",", module.compute.haproxy_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  Consul: ${join("\n          ", formatlist("ssh ubuntu@%s", split(",", module.data.consul_private_ips)))}
+
+  Vault: ${join("\n         ", formatlist("ssh ubuntu@%s", split(",", module.data.vault_private_ips)))}
+
+  HAProxy: ${join("\n           ", formatlist("ssh ubuntu@%s", split(",", module.compute.haproxy_private_ips)))}
+
 The VPC environment is accessible via an OpenVPN connection:
   Server:   ${module.network.openvpn_public_fqdn}
             ${module.network.openvpn_public_ip}
@@ -279,7 +283,8 @@ Use Consul DNS:
 Visit the HAProxy stats page:
   http://haproxy.service.consul:1936/haproxy?stats
   http://${module.compute.haproxy_private_fqdn}:1936/haproxy?stats
-  ${replace(formatlist("http://%s:1936/haproxy?stats\n  ", split(",", module.compute.haproxy_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  ${join("\n  ", formatlist("http://%s:1936/haproxy?stats", split(",", module.compute.haproxy_private_ips)))}
+
 Interact with Vault:
   Vault: ${module.data.vault_private_fqdn}
          http://vault.service.consul

--- a/terraform/providers/aws/us_east_1_staging/main.tf
+++ b/terraform/providers/aws/us_east_1_staging/main.tf
@@ -246,14 +246,18 @@ Visit the Node.js website:
 
   HAProxy: ${module.compute.haproxy_public_fqdn}
            ${join("\n           ", formatlist("http://%s/", split(",", module.compute.haproxy_public_ips)))}
+
 Add your private key and SSH into any private node via the Bastion host:
   ssh-add ../../../modules/keys/demo.pem
   ssh -A ${module.network.bastion_user}@${module.network.bastion_public_ip}
 
 Private node IPs:
-  Consul: ${replace(formatlist("ssh ubuntu@%s\n          ", split(",", module.data.consul_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  Vault: ${replace(formatlist("ssh ubuntu@%s\n         ", split(",", module.data.vault_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
-  HAProxy: ${replace(formatlist("ssh ubuntu@%s\n           ", split(",", module.compute.haproxy_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  Consul: ${join("\n          ", formatlist("ssh ubuntu@%s", split(",", module.data.consul_private_ips)))}
+
+  Vault: ${join("\n         ", formatlist("ssh ubuntu@%s", split(",", module.data.vault_private_ips)))}
+
+  HAProxy: ${join("\n           ", formatlist("ssh ubuntu@%s", split(",", module.compute.haproxy_private_ips)))}
+
 The VPC environment is accessible via an OpenVPN connection:
   Server:   ${module.network.openvpn_public_fqdn}
             ${module.network.openvpn_public_ip}
@@ -279,7 +283,8 @@ Use Consul DNS:
 Visit the HAProxy stats page:
   http://haproxy.service.consul:1936/haproxy?stats
   http://${module.compute.haproxy_private_fqdn}:1936/haproxy?stats
-  ${replace(formatlist("http://%s:1936/haproxy?stats\n  ", split(",", module.compute.haproxy_private_ips)), "B780FFEC-B661-4EB8-9236-A01737AD98B6", "")}
+  ${join("\n  ", formatlist("http://%s:1936/haproxy?stats", split(",", module.compute.haproxy_private_ips)))}
+
 Interact with Vault:
   Vault: ${module.data.vault_private_fqdn}
          http://vault.service.consul


### PR DESCRIPTION
Removing `leave_on_terminate` from Consul as well. When intentionally trying to kill nodes so they show as failed in the UI they would just gracefully leave (shutting down the machine, killing the service, sending an interrupt, etc.). We should be alerted when an agent fails.