### PR TITLE
Update Packer instance types to c3.large

### DIFF
--- a/packer/aws/ubuntu/base.json
+++ b/packer/aws/ubuntu/base.json
@@ -36,7 +36,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `us_east_1_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `us_east_1_name`}} {{timestamp}}",

--- a/packer/aws/ubuntu/consul.json
+++ b/packer/aws/ubuntu/consul.json
@@ -30,7 +30,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `base_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `name`}} {{timestamp}}",

--- a/packer/aws/ubuntu/haproxy.json
+++ b/packer/aws/ubuntu/haproxy.json
@@ -32,7 +32,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `base_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `name`}} {{timestamp}}",

--- a/packer/aws/ubuntu/nodejs.json
+++ b/packer/aws/ubuntu/nodejs.json
@@ -36,7 +36,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `base_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `name`}} {{timestamp}}",

--- a/packer/aws/ubuntu/rabbitmq.json
+++ b/packer/aws/ubuntu/rabbitmq.json
@@ -26,7 +26,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `base_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `name`}} {{timestamp}}",

--- a/packer/aws/ubuntu/vault.json
+++ b/packer/aws/ubuntu/vault.json
@@ -33,7 +33,7 @@
       "vpc_id":          "",
       "subnet_id":       "",
       "source_ami":      "{{user `base_ami`}}",
-      "instance_type":   "t2.micro",
+      "instance_type":   "c3.large",
       "ssh_username":    "{{user `ssh_username`}}",
       "ssh_timeout":     "10m",
       "ami_name":        "{{user `name`}} {{timestamp}}",


### PR DESCRIPTION
`c3.large` doesn't require a VPC, this will make on-boarding much easier. cc @clstokes 