### PR TITLE
Update Consul implementation

### DIFF
--- a/terraform/modules/aws/compute/haproxy/main.tf
+++ b/terraform/modules/aws/compute/haproxy/main.tf
@@ -6,10 +6,10 @@ variable "subnet_ids" {}
 variable "atlas_username" {}
 variable "atlas_environment" {}
 variable "atlas_token" {}
-variable "user_data" {}
-variable "nodes" {}
 variable "amis" {}
+variable "nodes" {}
 variable "instance_type" {}
+variable "user_data" {}
 variable "sub_domain" {}
 variable "route_zone_id" {}
 

--- a/terraform/modules/aws/compute/main.tf
+++ b/terraform/modules/aws/compute/main.tf
@@ -17,15 +17,15 @@ variable "sub_domain" {}
 variable "route_zone_id" {}
 variable "vault_token" { default = "" }
 
-variable "haproxy_user_data" {}
-variable "haproxy_nodes" {}
 variable "haproxy_amis" {}
+variable "haproxy_nodes" {}
 variable "haproxy_instance_type" {}
+variable "haproxy_user_data" {}
 
-variable "nodejs_user_data" {}
-variable "nodejs_nodes" {}
 variable "nodejs_ami" {}
+variable "nodejs_nodes" {}
 variable "nodejs_instance_type" {}
+variable "nodejs_user_data" {}
 
 module "haproxy" {
   source = "./haproxy"
@@ -38,10 +38,10 @@ module "haproxy" {
   atlas_username     = "${var.atlas_username}"
   atlas_environment  = "${var.atlas_environment}"
   atlas_token        = "${var.atlas_token}"
-  user_data          = "${var.haproxy_user_data}"
-  nodes              = "${var.haproxy_nodes}"
   amis               = "${var.haproxy_amis}"
+  nodes              = "${var.haproxy_nodes}"
   instance_type      = "${var.haproxy_instance_type}"
+  user_data          = "${var.haproxy_user_data}"
   sub_domain         = "${var.sub_domain}"
   route_zone_id      = "${var.route_zone_id}"
 }
@@ -64,10 +64,10 @@ module "nodejs" {
   atlas_environment  = "${var.atlas_environment}"
   atlas_aws_global   = "${var.atlas_aws_global}"
   atlas_token        = "${var.atlas_token}"
-  user_data          = "${var.nodejs_user_data}"
-  nodes              = "${var.nodejs_nodes}"
   ami                = "${var.nodejs_ami}"
+  nodes              = "${var.nodejs_nodes}"
   instance_type      = "${var.nodejs_instance_type}"
+  user_data          = "${var.nodejs_user_data}"
   sub_domain         = "${var.sub_domain}"
   route_zone_id      = "${var.route_zone_id}"
   vault_token        = "${var.vault_token}"

--- a/terraform/modules/aws/compute/nodejs/main.tf
+++ b/terraform/modules/aws/compute/nodejs/main.tf
@@ -27,8 +27,8 @@ resource "aws_security_group" "elb" {
   vpc_id      = "${var.vpc_id}"
   description = "Security group for Nodejs ELB"
 
+  tags      { Name = "${var.name}-elb" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}-elb" }
 
   ingress {
     protocol    = "tcp"
@@ -113,6 +113,8 @@ resource "terraform_remote_state" "aws_global" {
 resource "template_file" "user_data" {
   template = "${var.user_data}"
 
+  lifecycle { create_before_destroy = true }
+
   vars {
     atlas_username    = "${var.atlas_username}"
     atlas_environment = "${var.atlas_environment}"
@@ -123,12 +125,9 @@ resource "template_file" "user_data" {
     vault_token       = "${var.vault_token}"
     vault_policy      = "${var.vault_policy}"
     aws_region        = "${var.region}"
-
     aws_access_id     = "${element(split(",", terraform_remote_state.aws_global.output.iam_vault_access_ids), index(split(",", terraform_remote_state.aws_global.output.iam_vault_users), format("vault-%s", var.atlas_environment)))}"
     aws_secret_key    = "${element(split(",", terraform_remote_state.aws_global.output.iam_vault_secret_keys), index(split(",", terraform_remote_state.aws_global.output.iam_vault_users), format("vault-%s", var.atlas_environment)))}"
   }
-
-  lifecycle { create_before_destroy = true }
 }
 
 module "asg" {

--- a/terraform/modules/aws/compute/nodejs/main.tf
+++ b/terraform/modules/aws/compute/nodejs/main.tf
@@ -13,10 +13,10 @@ variable "atlas_username" {}
 variable "atlas_environment" {}
 variable "atlas_aws_global" {}
 variable "atlas_token" {}
-variable "user_data" {}
-variable "nodes" {}
 variable "ami" {}
+variable "nodes" {}
 variable "instance_type" {}
+variable "user_data" {}
 variable "sub_domain" {}
 variable "route_zone_id" {}
 variable "vault_token" { default = "" }

--- a/terraform/modules/aws/data/main.tf
+++ b/terraform/modules/aws/data/main.tf
@@ -13,15 +13,20 @@ variable "atlas_token" {}
 variable "sub_domain" {}
 variable "route_zone_id" {}
 
-variable "consul_user_data" {}
-variable "consul_instance_type" {}
-variable "consul_ips" {}
 variable "consul_amis" {}
+variable "consul_nodes" {}
+variable "consul_instance_type" {}
+variable "consul_user_data" {}
+variable "openvpn_user" {}
+variable "openvpn_host" {}
+variable "key_file" {}
+variable "bastion_host" {}
+variable "bastion_user" {}
 
-variable "vault_user_data" {}
-variable "vault_instance_type" {}
-variable "vault_nodes" {}
 variable "vault_amis" {}
+variable "vault_nodes" {}
+variable "vault_instance_type" {}
+variable "vault_user_data" {}
 
 module "consul" {
   source = "./consul"
@@ -34,10 +39,15 @@ module "consul" {
   atlas_username     = "${var.atlas_username}"
   atlas_environment  = "${var.atlas_environment}"
   atlas_token        = "${var.atlas_token}"
-  user_data          = "${var.consul_user_data}"
-  instance_type      = "${var.consul_instance_type}"
-  static_ips         = "${var.consul_ips}"
   amis               = "${var.consul_amis}"
+  nodes              = "${var.consul_nodes}"
+  instance_type      = "${var.consul_instance_type}"
+  user_data          = "${var.consul_user_data}"
+  openvpn_user       = "${var.openvpn_user}"
+  openvpn_host       = "${var.openvpn_host}"
+  key_file           = "${var.key_file}"
+  bastion_host       = "${var.bastion_host}"
+  bastion_user       = "${var.bastion_user}"
 }
 
 module "vault" {
@@ -55,10 +65,10 @@ module "vault" {
   atlas_username     = "${var.atlas_username}"
   atlas_environment  = "${var.atlas_environment}"
   atlas_token        = "${var.atlas_token}"
-  user_data          = "${var.vault_user_data}"
-  instance_type      = "${var.vault_instance_type}"
-  nodes              = "${var.vault_nodes}"
   amis               = "${var.vault_amis}"
+  nodes              = "${var.vault_nodes}"
+  instance_type      = "${var.vault_instance_type}"
+  user_data          = "${var.vault_user_data}"
   sub_domain         = "${var.sub_domain}"
   route_zone_id      = "${var.route_zone_id}"
 }

--- a/terraform/modules/aws/data/vault/main.tf
+++ b/terraform/modules/aws/data/vault/main.tf
@@ -10,10 +10,10 @@ variable "key_name" {}
 variable "atlas_username" {}
 variable "atlas_environment" {}
 variable "atlas_token" {}
-variable "user_data" {}
-variable "instance_type" {}
-variable "nodes" {}
 variable "amis" {}
+variable "nodes" {}
+variable "instance_type" {}
+variable "user_data" {}
 variable "sub_domain" {}
 variable "route_zone_id" {}
 
@@ -22,7 +22,8 @@ resource "aws_security_group" "vault" {
   vpc_id      = "${var.vpc_id}"
   description = "Security group for Vault"
 
-  tags { Name = "${var.name}" }
+  tags      { Name = "${var.name}" }
+  lifecycle { create_before_destroy = true }
 
   ingress {
     protocol    = -1
@@ -42,6 +43,8 @@ resource "aws_security_group" "vault" {
 resource "template_file" "user_data" {
   count    = "${var.nodes}"
   template = "${var.user_data}"
+
+  lifecycle { create_before_destroy = true }
 
   vars {
     atlas_username    = "${var.atlas_username}"
@@ -63,7 +66,8 @@ resource "aws_instance" "vault" {
 
   vpc_security_group_ids = ["${aws_security_group.vault.id}"]
 
-  tags { Name = "${var.name}.${count.index+1}" }
+  tags      { Name = "${var.name}.${count.index+1}" }
+  lifecycle { create_before_destroy = true }
 }
 
 resource "aws_security_group" "elb" {

--- a/terraform/modules/aws/network/bastion/main.tf
+++ b/terraform/modules/aws/network/bastion/main.tf
@@ -11,8 +11,8 @@ resource "aws_security_group" "bastion" {
   vpc_id      = "${var.vpc_id}"
   description = "Bastion security group"
 
+  tags      { Name = "${var.name}" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}" }
 
   ingress {
     protocol    = -1
@@ -50,8 +50,8 @@ resource "aws_instance" "bastion" {
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
 
+  tags      { Name = "${var.name}" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}" }
 }
 
 output "user"       { value = "ubuntu" }

--- a/terraform/modules/aws/network/main.tf
+++ b/terraform/modules/aws/network/main.tf
@@ -16,9 +16,9 @@ variable "bastion_instance_type" {}
 variable "nat_instance_type" {}
 variable "openvpn_instance_type" {}
 variable "openvpn_ami" {}
+variable "openvpn_user" {}
 variable "openvpn_admin_user" {}
 variable "openvpn_admin_pw" {}
-variable "openvpn_dns_ips" {}
 variable "openvpn_cidr" {}
 
 module "vpc" {
@@ -97,24 +97,24 @@ module "ephemeral_subnets" {
 module "openvpn" {
   source = "./openvpn"
 
-  name              = "${var.name}-openvpn"
-  vpc_id            = "${module.vpc.vpc_id}"
-  vpc_cidr          = "${module.vpc.vpc_cidr}"
-  public_subnet_ids = "${module.public_subnet.subnet_ids}"
-  ssl_cert          = "${var.ssl_cert}"
-  ssl_key           = "${var.ssl_key}"
-  key_name          = "${var.key_name}"
-  key_file          = "${var.key_file}"
-  ami               = "${var.openvpn_ami}"
-  instance_type     = "${var.openvpn_instance_type}"
-  bastion_host      = "${module.bastion.public_ip}"
-  bastion_user      = "${module.bastion.user}"
-  admin_user        = "${var.openvpn_admin_user}"
-  admin_pw          = "${var.openvpn_admin_pw}"
-  dns_ips           = "${var.openvpn_dns_ips}"
-  vpn_cidr          = "${var.openvpn_cidr}"
-  sub_domain        = "${var.sub_domain}"
-  route_zone_id     = "${var.route_zone_id}"
+  name               = "${var.name}-openvpn"
+  vpc_id             = "${module.vpc.vpc_id}"
+  vpc_cidr           = "${module.vpc.vpc_cidr}"
+  public_subnet_ids  = "${module.public_subnet.subnet_ids}"
+  ssl_cert           = "${var.ssl_cert}"
+  ssl_key            = "${var.ssl_key}"
+  key_name           = "${var.key_name}"
+  key_file           = "${var.key_file}"
+  ami                = "${var.openvpn_ami}"
+  instance_type      = "${var.openvpn_instance_type}"
+  bastion_host       = "${module.bastion.public_ip}"
+  bastion_user       = "${module.bastion.user}"
+  openvpn_user       = "${var.openvpn_user}"
+  openvpn_admin_user = "${var.openvpn_admin_user}"
+  openvpn_admin_pw   = "${var.openvpn_admin_pw}"
+  vpn_cidr           = "${var.openvpn_cidr}"
+  sub_domain         = "${var.sub_domain}"
+  route_zone_id      = "${var.route_zone_id}"
 }
 
 resource "aws_network_acl" "acl" {

--- a/terraform/modules/aws/network/private_subnet/main.tf
+++ b/terraform/modules/aws/network/private_subnet/main.tf
@@ -10,8 +10,8 @@ resource "aws_subnet" "private" {
   availability_zone = "${element(split(",", var.azs), count.index)}"
   count             = "${length(split(",", var.cidrs))}"
 
+  tags      { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
 }
 
 resource "aws_route_table" "private" {
@@ -23,8 +23,8 @@ resource "aws_route_table" "private" {
     instance_id = "${element(split(",", var.nat_instance_ids), count.index)}"
   }
 
+  tags      { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
 }
 
 resource "aws_route_table_association" "private" {

--- a/terraform/modules/aws/network/public_subnet/main.tf
+++ b/terraform/modules/aws/network/public_subnet/main.tf
@@ -15,8 +15,8 @@ resource "aws_subnet" "public" {
   availability_zone = "${element(split(",", var.azs), count.index)}"
   count             = "${length(split(",", var.cidrs))}"
 
+  tags      { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
   lifecycle { create_before_destroy = true }
-  tags { Name = "${var.name}.${element(split(",", var.azs), count.index)}" }
 
   map_public_ip_on_launch = true
 }

--- a/terraform/modules/aws/network/vpc/main.tf
+++ b/terraform/modules/aws/network/vpc/main.tf
@@ -6,7 +6,7 @@ resource "aws_vpc" "vpc" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags { Name = "${var.name}" }
+  tags      { Name = "${var.name}" }
   lifecycle { create_before_destroy = true }
 }
 

--- a/terraform/modules/aws/util/artifact/main.tf
+++ b/terraform/modules/aws/util/artifact/main.tf
@@ -11,6 +11,7 @@ resource "atlas_artifact" "latest" {
   version  = "latest"
 
   lifecycle { create_before_destroy = true }
+
   metadata {
     region = "${var.region}"
   }
@@ -22,6 +23,7 @@ resource "atlas_artifact" "pinned" {
   version  = "${var.pinned_version}"
 
   lifecycle { create_before_destroy = true }
+
   metadata {
     region = "${var.region}"
   }

--- a/terraform/modules/aws/util/asg/main.tf
+++ b/terraform/modules/aws/util/asg/main.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "asg" {
   vpc_id      = "${var.vpc_id}"
   description = "Security group for ${var.name} Launch Configuration"
 
-  tags { Name = "${var.name}" }
+  tags      { Name = "${var.name}" }
   lifecycle { create_before_destroy = true }
 
   ingress {

--- a/terraform/modules/scripts/ubuntu/nodejs.sh
+++ b/terraform/modules/scripts/ubuntu/nodejs.sh
@@ -42,13 +42,6 @@ sed -i -- "s/{{ node_name }}/$NAME/g" /etc/consul.d/base.json
 
 service consul restart
 
-if [[ "x${vault_token}" == "x" || "${vault_token}" == "REPLACE_IN_ATLAS" ]]; then
-  logger "Exiting without setting Vault policy due to no Vault token."
-  sed -i -- "s/retry = \"5s\"/retry = \"24h\"/g" /etc/consul_template.d/base.hcl
-
-  exit 1
-fi
-
 logger "Updating certs..."
 
 mkdir -p $SSLCERTDIR
@@ -60,6 +53,15 @@ echo "${vault_ssl_cert}" | sudo tee $SSLVAULTCERTPATH > /dev/null
 cp $SSLSITECERTPATH /usr/local/share/ca-certificates/.
 cp $SSLVAULTCERTPATH /usr/local/share/ca-certificates/.
 update-ca-certificates
+
+logger "Checking for Vault token..."
+
+if [[ "x${vault_token}" == "x" || "${vault_token}" == "REPLACE_IN_ATLAS" ]]; then
+  logger "Exiting without setting Vault policy due to no Vault token."
+  sed -i -- "s/retry = \"5s\"/retry = \"24h\"/g" /etc/consul_template.d/base.hcl
+
+  exit 1
+fi
 
 logger "Waiting for Vault to become ready..."
 

--- a/terraform/providers/aws/us_east_1_prod/main.tf
+++ b/terraform/providers/aws/us_east_1_prod/main.tf
@@ -15,10 +15,10 @@ variable "vault_ssl_key" {}
 variable "vault_token" { default = "" }
 
 variable "vpc_cidr" {}
+variable "azs" {}
 variable "private_subnets" {}
 variable "ephemeral_subnets" {}
 variable "public_subnets" {}
-variable "azs" {}
 
 variable "bastion_instance_type" {}
 variable "nat_instance_type" {}
@@ -42,14 +42,14 @@ variable "vault_latest_name" {}
 variable "vault_pinned_name" {}
 variable "vault_pinned_version" {}
 
-variable "haproxy_instance_type" {}
 variable "haproxy_nodes" {}
+variable "haproxy_instance_type" {}
 variable "haproxy_latest_name" {}
 variable "haproxy_pinned_name" {}
 variable "haproxy_pinned_version" {}
 
-variable "nodejs_instance_type" {}
 variable "nodejs_nodes" {}
+variable "nodejs_instance_type" {}
 variable "nodejs_latest_name" {}
 variable "nodejs_pinned_name" {}
 variable "nodejs_pinned_version" {}
@@ -208,15 +208,15 @@ module "compute" {
   route_zone_id      = "${terraform_remote_state.aws_global.output.zone_id}"
   vault_token        = "${var.vault_token}"
 
-  haproxy_user_data     = "${module.scripts.ubuntu_consul_client_user_data}"
-  haproxy_nodes         = "${var.haproxy_nodes}"
   haproxy_amis          = "${module.artifact_haproxy.latest}"
+  haproxy_nodes         = "${var.haproxy_nodes}"
   haproxy_instance_type = "${var.haproxy_instance_type}"
+  haproxy_user_data     = "${module.scripts.ubuntu_consul_client_user_data}"
 
-  nodejs_user_data     = "${module.scripts.ubuntu_nodejs_user_data}"
-  nodejs_nodes         = "${var.nodejs_nodes}"
   nodejs_ami           = "${module.artifact_nodejs.latest}"
+  nodejs_nodes         = "${var.nodejs_nodes}"
   nodejs_instance_type = "${var.nodejs_instance_type}"
+  nodejs_user_data     = "${module.scripts.ubuntu_nodejs_user_data}"
 }
 
 module "website" {

--- a/terraform/providers/aws/us_east_1_prod/main.tf
+++ b/terraform/providers/aws/us_east_1_prod/main.tf
@@ -25,11 +25,12 @@ variable "nat_instance_type" {}
 
 variable "openvpn_instance_type" {}
 variable "openvpn_ami" {}
+variable "openvpn_user" {}
 variable "openvpn_admin_user" {}
 variable "openvpn_admin_pw" {}
 variable "openvpn_cidr" {}
 
-variable "consul_ips" {}
+variable "consul_nodes" {}
 variable "consul_instance_type" {}
 variable "consul_latest_name" {}
 variable "consul_pinned_name" {}
@@ -101,9 +102,9 @@ module "network" {
   nat_instance_type     = "${var.nat_instance_type}"
   openvpn_instance_type = "${var.openvpn_instance_type}"
   openvpn_ami           = "${var.openvpn_ami}"
+  openvpn_user          = "${var.openvpn_user}"
   openvpn_admin_user    = "${var.openvpn_admin_user}"
   openvpn_admin_pw      = "${var.openvpn_admin_pw}"
-  openvpn_dns_ips       = "${var.consul_ips}"
   openvpn_cidr          = "${var.openvpn_cidr}"
 }
 
@@ -147,15 +148,20 @@ module "data" {
   sub_domain         = "${var.sub_domain}"
   route_zone_id      = "${terraform_remote_state.aws_global.output.zone_id}"
 
-  consul_user_data     = "${module.scripts.ubuntu_consul_server_user_data}"
-  consul_instance_type = "${var.consul_instance_type}"
-  consul_ips           = "${var.consul_ips}"
   consul_amis          = "${module.artifact_consul.latest},${module.artifact_consul.latest},${module.artifact_consul.latest}"
+  consul_nodes         = "${var.consul_nodes}"
+  consul_instance_type = "${var.consul_instance_type}"
+  consul_user_data     = "${module.scripts.ubuntu_consul_server_user_data}"
+  openvpn_user         = "${var.openvpn_user}"
+  openvpn_host         = "${module.network.openvpn_private_ip}"
+  key_file             = "${var.site_private_key}"
+  bastion_host         = "${module.network.bastion_public_ip}"
+  bastion_user         = "${module.network.bastion_user}"
 
-  vault_user_data     = "${module.scripts.ubuntu_vault_user_data}"
-  vault_instance_type = "${var.vault_instance_type}"
-  vault_nodes         = "${var.vault_nodes}"
   vault_amis          = "${module.artifact_vault.latest},${module.artifact_vault.latest}"
+  vault_nodes         = "${var.vault_nodes}"
+  vault_instance_type = "${var.vault_instance_type}"
+  vault_user_data     = "${module.scripts.ubuntu_vault_user_data}"
 }
 
 module "artifact_haproxy" {

--- a/terraform/providers/aws/us_east_1_prod/terraform.tfvars
+++ b/terraform/providers/aws/us_east_1_prod/terraform.tfvars
@@ -51,6 +51,7 @@ nat_instance_type = "t2.micro"
 # OpenVPN - https://docs.openvpn.net/how-to-tutorialsguides/virtual-platforms/amazon-ec2-appliance-ami-quick-start-guide/
 openvpn_instance_type = "t2.micro"
 openvpn_ami           = "ami-5fe36434"
+openvpn_user          = "openvpnas"
 openvpn_admin_user    = "vpnadmin"
 openvpn_admin_pw      = "sdEKxN2dwDK4FziU6QEKjUeegcC8ZfBYA3fzMgqXfocgQvWGRw"
 openvpn_cidr          = "172.27.139.0/24"
@@ -60,7 +61,7 @@ openvpn_cidr          = "172.27.139.0/24"
 #--------------------------------------------------------------
 
 # Consul
-consul_ips            = "10.139.1.4,10.139.2.4,10.139.3.4"
+consul_nodes          = "3"
 consul_instance_type  = "t2.small"
 consul_latest_name    = "aws-us-east-1-ubuntu-consul"
 consul_pinned_name    = "aws-us-east-1-ubuntu-consul"

--- a/terraform/providers/aws/us_east_1_prod/terraform.tfvars
+++ b/terraform/providers/aws/us_east_1_prod/terraform.tfvars
@@ -34,13 +34,10 @@ vault_token       = "REPLACE_IN_ATLAS" # No need to update until Vault is config
 #--------------------------------------------------------------
 
 vpc_cidr          = "10.139.0.0/16"
-private_subnets   = "10.139.1.0/24,10.139.2.0/24,10.139.3.0/24"
-ephemeral_subnets = "10.139.11.0/24,10.139.12.0/24,10.139.13.0/24"
-public_subnets    = "10.139.101.0/24,10.139.102.0/24,10.139.103.0/24"
-
-# Some subnets may only be able to be created in specific
-# availability zones depending on your AWS account
-azs = "us-east-1a,us-east-1c,us-east-1e"
+azs               = "us-east-1a,us-east-1c,us-east-1e" # AZs are region specific
+private_subnets   = "10.139.1.0/24,10.139.2.0/24,10.139.3.0/24" # Creating one private subnet per AZ
+ephemeral_subnets = "10.139.11.0/24,10.139.12.0/24,10.139.13.0/24" # Creating one ephemeral subnet per AZ
+public_subnets    = "10.139.101.0/24,10.139.102.0/24,10.139.103.0/24" # Creating one public subnet per AZ
 
 # Bastion
 bastion_instance_type = "t2.micro"
@@ -78,14 +75,14 @@ vault_pinned_version  = "latest"
 # Compute
 #--------------------------------------------------------------
 
-haproxy_instance_type  = "t2.micro"
 haproxy_nodes          = "1"
+haproxy_instance_type  = "t2.micro"
 haproxy_latest_name    = "aws-us-east-1-ubuntu-haproxy"
 haproxy_pinned_name    = "aws-us-east-1-ubuntu-haproxy"
 haproxy_pinned_version = "latest"
 
-nodejs_instance_type  = "t2.micro"
 nodejs_nodes          = "2"
+nodejs_instance_type  = "t2.micro"
 nodejs_latest_name    = "aws-us-east-1-ubuntu-nodejs"
 nodejs_pinned_name    = "aws-us-east-1-ubuntu-nodejs"
 nodejs_pinned_version = "latest"

--- a/terraform/providers/aws/us_east_1_staging/main.tf
+++ b/terraform/providers/aws/us_east_1_staging/main.tf
@@ -15,10 +15,10 @@ variable "vault_ssl_key" {}
 variable "vault_token" { default = "" }
 
 variable "vpc_cidr" {}
+variable "azs" {}
 variable "private_subnets" {}
 variable "ephemeral_subnets" {}
 variable "public_subnets" {}
-variable "azs" {}
 
 variable "bastion_instance_type" {}
 variable "nat_instance_type" {}
@@ -42,14 +42,14 @@ variable "vault_latest_name" {}
 variable "vault_pinned_name" {}
 variable "vault_pinned_version" {}
 
-variable "haproxy_instance_type" {}
 variable "haproxy_nodes" {}
+variable "haproxy_instance_type" {}
 variable "haproxy_latest_name" {}
 variable "haproxy_pinned_name" {}
 variable "haproxy_pinned_version" {}
 
-variable "nodejs_instance_type" {}
 variable "nodejs_nodes" {}
+variable "nodejs_instance_type" {}
 variable "nodejs_latest_name" {}
 variable "nodejs_pinned_name" {}
 variable "nodejs_pinned_version" {}
@@ -208,15 +208,15 @@ module "compute" {
   route_zone_id      = "${terraform_remote_state.aws_global.output.zone_id}"
   vault_token        = "${var.vault_token}"
 
-  haproxy_user_data     = "${module.scripts.ubuntu_consul_client_user_data}"
-  haproxy_nodes         = "${var.haproxy_nodes}"
   haproxy_amis          = "${module.artifact_haproxy.latest}"
+  haproxy_nodes         = "${var.haproxy_nodes}"
   haproxy_instance_type = "${var.haproxy_instance_type}"
+  haproxy_user_data     = "${module.scripts.ubuntu_consul_client_user_data}"
 
-  nodejs_user_data     = "${module.scripts.ubuntu_nodejs_user_data}"
-  nodejs_nodes         = "${var.nodejs_nodes}"
   nodejs_ami           = "${module.artifact_nodejs.latest}"
+  nodejs_nodes         = "${var.nodejs_nodes}"
   nodejs_instance_type = "${var.nodejs_instance_type}"
+  nodejs_user_data     = "${module.scripts.ubuntu_nodejs_user_data}"
 }
 
 module "website" {

--- a/terraform/providers/aws/us_east_1_staging/main.tf
+++ b/terraform/providers/aws/us_east_1_staging/main.tf
@@ -25,11 +25,12 @@ variable "nat_instance_type" {}
 
 variable "openvpn_instance_type" {}
 variable "openvpn_ami" {}
+variable "openvpn_user" {}
 variable "openvpn_admin_user" {}
 variable "openvpn_admin_pw" {}
 variable "openvpn_cidr" {}
 
-variable "consul_ips" {}
+variable "consul_nodes" {}
 variable "consul_instance_type" {}
 variable "consul_latest_name" {}
 variable "consul_pinned_name" {}
@@ -101,9 +102,9 @@ module "network" {
   nat_instance_type     = "${var.nat_instance_type}"
   openvpn_instance_type = "${var.openvpn_instance_type}"
   openvpn_ami           = "${var.openvpn_ami}"
+  openvpn_user          = "${var.openvpn_user}"
   openvpn_admin_user    = "${var.openvpn_admin_user}"
   openvpn_admin_pw      = "${var.openvpn_admin_pw}"
-  openvpn_dns_ips       = "${var.consul_ips}"
   openvpn_cidr          = "${var.openvpn_cidr}"
 }
 
@@ -147,15 +148,20 @@ module "data" {
   sub_domain         = "${var.sub_domain}"
   route_zone_id      = "${terraform_remote_state.aws_global.output.zone_id}"
 
-  consul_user_data     = "${module.scripts.ubuntu_consul_server_user_data}"
-  consul_instance_type = "${var.consul_instance_type}"
-  consul_ips           = "${var.consul_ips}"
   consul_amis          = "${module.artifact_consul.latest},${module.artifact_consul.latest},${module.artifact_consul.latest}"
+  consul_nodes         = "${var.consul_nodes}"
+  consul_instance_type = "${var.consul_instance_type}"
+  consul_user_data     = "${module.scripts.ubuntu_consul_server_user_data}"
+  openvpn_user         = "${var.openvpn_user}"
+  openvpn_host         = "${module.network.openvpn_private_ip}"
+  key_file             = "${var.site_private_key}"
+  bastion_host         = "${module.network.bastion_public_ip}"
+  bastion_user         = "${module.network.bastion_user}"
 
-  vault_user_data     = "${module.scripts.ubuntu_vault_user_data}"
-  vault_instance_type = "${var.vault_instance_type}"
-  vault_nodes         = "${var.vault_nodes}"
   vault_amis          = "${module.artifact_vault.latest},${module.artifact_vault.latest}"
+  vault_nodes         = "${var.vault_nodes}"
+  vault_instance_type = "${var.vault_instance_type}"
+  vault_user_data     = "${module.scripts.ubuntu_vault_user_data}"
 }
 
 module "artifact_haproxy" {

--- a/terraform/providers/aws/us_east_1_staging/terraform.tfvars
+++ b/terraform/providers/aws/us_east_1_staging/terraform.tfvars
@@ -51,6 +51,7 @@ nat_instance_type = "t2.micro"
 # OpenVPN - https://docs.openvpn.net/how-to-tutorialsguides/virtual-platforms/amazon-ec2-appliance-ami-quick-start-guide/
 openvpn_instance_type = "t2.micro"
 openvpn_ami           = "ami-5fe36434"
+openvpn_user          = "openvpnas"
 openvpn_admin_user    = "vpnadmin"
 openvpn_admin_pw      = "sdEKxN2dwDK4FziU6QEKjUeegcC8ZfBYA3fzMgqXfocgQvWGRw"
 openvpn_cidr          = "172.27.139.0/24"
@@ -60,7 +61,7 @@ openvpn_cidr          = "172.27.139.0/24"
 #--------------------------------------------------------------
 
 # Consul
-consul_ips            = "10.139.1.4,10.139.2.4,10.139.3.4"
+consul_nodes          = "3"
 consul_instance_type  = "t2.small"
 consul_latest_name    = "aws-us-east-1-ubuntu-consul"
 consul_pinned_name    = "aws-us-east-1-ubuntu-consul"

--- a/terraform/providers/aws/us_east_1_staging/terraform.tfvars
+++ b/terraform/providers/aws/us_east_1_staging/terraform.tfvars
@@ -34,13 +34,10 @@ vault_token       = "REPLACE_IN_ATLAS" # No need to update until Vault is config
 #--------------------------------------------------------------
 
 vpc_cidr          = "10.139.0.0/16"
-private_subnets   = "10.139.1.0/24,10.139.2.0/24,10.139.3.0/24"
-ephemeral_subnets = "10.139.11.0/24,10.139.12.0/24,10.139.13.0/24"
-public_subnets    = "10.139.101.0/24,10.139.102.0/24,10.139.103.0/24"
-
-# Some subnets may only be able to be created in specific
-# availability zones depending on your AWS account
-azs = "us-east-1a,us-east-1c,us-east-1e"
+azs               = "us-east-1a,us-east-1c,us-east-1e" # AZs are region specific
+private_subnets   = "10.139.1.0/24,10.139.2.0/24,10.139.3.0/24" # Creating one private subnet per AZ
+ephemeral_subnets = "10.139.11.0/24,10.139.12.0/24,10.139.13.0/24" # Creating one ephemeral subnet per AZ
+public_subnets    = "10.139.101.0/24,10.139.102.0/24,10.139.103.0/24" # Creating one public subnet per AZ
 
 # Bastion
 bastion_instance_type = "t2.micro"
@@ -78,14 +75,14 @@ vault_pinned_version  = "latest"
 # Compute
 #--------------------------------------------------------------
 
-haproxy_instance_type  = "t2.micro"
 haproxy_nodes          = "1"
+haproxy_instance_type  = "t2.micro"
 haproxy_latest_name    = "aws-us-east-1-ubuntu-haproxy"
 haproxy_pinned_name    = "aws-us-east-1-ubuntu-haproxy"
 haproxy_pinned_version = "latest"
 
-nodejs_instance_type  = "t2.micro"
 nodejs_nodes          = "2"
+nodejs_instance_type  = "t2.micro"
 nodejs_latest_name    = "aws-us-east-1-ubuntu-nodejs"
 nodejs_pinned_name    = "aws-us-east-1-ubuntu-nodejs"
 nodejs_pinned_version = "latest"


### PR DESCRIPTION
Previously we got the Consul server count based on the the number of static IPs that were being used.

This removes the need for static Consul ips by adding a `null_resource` provisioner to update the OpenVPN instance DNS with Consul IPs after the Consul nodes are provisioned.

Also added a Consul node count variable so we are consistent with the other resources being provisioned.