### PR TITLE
Remove duplicate vault init

### DIFF
--- a/terraform/providers/aws/README.md
+++ b/terraform/providers/aws/README.md
@@ -252,10 +252,6 @@ A HA Vault should have already been provisioned, but you'll need to initialize a
 
     `$ vault init | tee /tmp/vault.init > /dev/null`
 
-- [ ] Initialize Vault
-
-    `$ vault init | tee /tmp/vault.init > /dev/null`
-
 - [ ] Retrieve the unseal keys and root token from `/tmp/vault.init` and store these in a safe place
 - [ ] Shred keys and token once they are stored in a safe place
 


### PR DESCRIPTION
I can't think of a reason why you would want to init twice, so I assume it's a typo/bad merge.