### PR TITLE
Update version to fix Consul leak

### DIFF
--- a/packer/scripts/ubuntu/consul.sh
+++ b/packer/scripts/ubuntu/consul.sh
@@ -3,7 +3,7 @@ set -e
 
 cd /tmp
 
-CONSULVERSION=0.6.1
+CONSULVERSION=0.6.3
 CONFIGDIR=/ops/$1
 SCRIPTSDIR=/ops/$2
 CONSULDOWNLOAD=https://releases.hashicorp.com/consul/${CONSULVERSION}/consul_${CONSULVERSION}_linux_amd64.zip

--- a/packer/scripts/ubuntu/consul_template.sh
+++ b/packer/scripts/ubuntu/consul_template.sh
@@ -3,7 +3,7 @@ set -e
 
 cd /tmp
 
-CTVERSION=0.12.1
+CTVERSION=0.12.2
 CONFIGDIR=/ops/$1
 SCRIPTSDIR=/ops/$2
 CTDOWNLOAD=https://releases.hashicorp.com/consul-template/${CTVERSION}/consul-template_${CTVERSION}_linux_amd64.zip

--- a/packer/scripts/ubuntu/vault.sh
+++ b/packer/scripts/ubuntu/vault.sh
@@ -3,7 +3,7 @@ set -e
 
 cd /tmp
 
-VAULTVERSION=0.4.0
+VAULTVERSION=0.5.0-rc2
 CONFIGDIR=/ops/$1
 SCRIPTSDIR=/ops/$2
 VAULTDOWNLOAD=https://releases.hashicorp.com/vault/${VAULTVERSION}/vault_${VAULTVERSION}_linux_amd64.zip


### PR DESCRIPTION
Consul has a leak right now that screws with consul-template and Vault working. Updating the Vault version fixes that . This was the fix -->  https://github.com/hashicorp/go-cleanhttp/commit/ce617e79981a8fff618bb643d155133a8f38db96