### PR TITLE
Fix custom check.id and check.name not working

### DIFF
--- a/packer/config/consul/nodejs.json
+++ b/packer/config/consul/nodejs.json
@@ -2,13 +2,14 @@
   "service": {
     "name": "web",
     "port": 8888,
-    "tags": ["nodejs", "{{ deploy }}"],
-    "check": {
-      "id": "nodejs",
-      "name": "Running on port 8888",
-      "http": "http://localhost:8888",
-      "interval": "10s",
-      "timeout": "1s"
-    }
+    "tags": ["nodejs", "{{ deploy }}"]
+  },
+  "check": {
+    "id": "nodejs",
+    "service_id": "web",
+    "name": "Running on port 8888",
+    "http": "http://localhost:8888",
+    "interval": "10s",
+    "timeout": "1s"
   }
 }


### PR DESCRIPTION
When configured the current way, check.id and check.name are not used as expected.

see: hashicorp/consul#740