### PR TITLE
Update setup_vault.sh to make it work with v0.6.1

### DIFF
--- a/packer/config/vault/scripts/setup_vault.sh
+++ b/packer/config/vault/scripts/setup_vault.sh
@@ -20,7 +20,7 @@ if [ ! $(cget root-token) ]; then
 
   # Store master keys in consul for operator to retrieve and remove
   COUNTER=1
-  cat /tmp/vault.init | grep '^Key' | awk '{print $3}' | for key in $(cat -); do
+  cat /tmp/vault.init | grep '\(hex\)' | awk '{print $6}' | for key in $(cat -); do
     curl -fX PUT 127.0.0.1:8500/v1/kv/service/vault/unseal-key-$COUNTER -d $key
     COUNTER=$((COUNTER + 1))
   done


### PR DESCRIPTION
`vault init` output format on v0.6.1 is:
```
Unseal Key 1 (hex)   :  <hex string>
Unseal Key 1 (base64): <base64 string>
...
```
Make change to the line to parse vault.init output file to get hex unseal keys.