### PR TITLE
AWS: remove nodejs dependency on Atlas Applications

### DIFF
--- a/packer/aws/ubuntu/nodejs.json
+++ b/packer/aws/ubuntu/nodejs.json
@@ -9,8 +9,7 @@
     "ssh_username":   "ubuntu",
     "scripts_dir":    "scripts/ubuntu",
     "config_dir":     "config",
-    "host_app_dir":   "/application",
-    "slug_app_dir":   "app/"
+    "host_app_dir":   "/application"
   },
   "push": {
     "name": "{{user `atlas_username`}}/{{user `name`}}",
@@ -18,6 +17,7 @@
     "include": [
       "{{user `scripts_dir`}}/*",
       "{{user `scripts_dir`}}/upstart/*",
+      "{{user `scripts_dir`}}/nodejs_app/*",
       "{{user `config_dir`}}/*",
       "{{user `config_dir`}}/consul/*",
       "{{user `config_dir`}}/consul_template/*",
@@ -79,7 +79,7 @@
     },
     {
       "type": "file",
-      "source": "{{user `slug_app_dir`}}",
+      "source": "{{user `scripts_dir`}}/nodejs_app/",
       "destination": "{{user `host_app_dir`}}"
     },
     {

--- a/terraform/providers/aws/README.md
+++ b/terraform/providers/aws/README.md
@@ -156,25 +156,6 @@ We built artifacts for the `us-east-1` region in this walkthrough. If you'd like
 
 If you decide to update any of the artifact names, be sure those name changes are reflected in your `terraform.tfvars` file(s).
 
-### Deploy a `us-east-1` Node.js Application
-
-- [ ] Fork the [`demo-app-nodejs` repo](https://github.com/hashicorp/demo-app-nodejs)
-- [ ] Use the [New Application](https://atlas.hashicorp.com/applications/new) tool to create your Node.js Application
-  - [ ] **Choose a name for the application**: `aws-us-east-1-nodejs`
-  - [ ] **Compile Application**: checked
-  - [ ] **Build Template**: `aws-us-east-1-ubuntu-nodejs`
-  - [ ] **Connect application to a GitHub repository**
-    - [ ] **GitHub repository**: `demo-app-nodejs`
-    - [ ] Leave both **Application directory** and **Application Template** blank
-
-Upload new versions of the application by merging a commit into master from your forked repo. This will upload your latest app code and trigger a Packer build to create a new compiled application artifact.
-
-If you don't have a change to make, you can force an application ingress into Atlas with an empty commit.
-
-    $ git commit --allow-empty -m "Force a change in Atlas"
-
-If you want to create artifacts in other regions, complete these same steps but select a Build Template from the region you'd like.
-
 ### Provision the `aws-global` Environment
 
 - [ ] Use the [Import Terraform Configuration from GitHub](https://atlas.hashicorp.com/configurations/import) tool to import the `aws-global` Environment from GitHub


### PR DESCRIPTION
Modifies the AWS NodeJS Packer build tempate to use the [embedded application](https://github.com/hashicorp/best-practices/tree/master/packer/scripts/ubuntu/nodejs_app) rather than the [demo app repo ](https://github.com/hashicorp/demo-app-nodejs). Eliminates the dependency on the Atlas Application feature which has been deprecated. Mirrors how the app is deployed on the Google provider.