### PR TITLE
Overly restrictive umask bug breaks gen_cert.sh for non-root users.

### DIFF
--- a/setup/gen_cert.sh
+++ b/setup/gen_cert.sh
@@ -88,7 +88,7 @@ main() {
     usage
   fi
 
-  umask 277
+  umask 077
 
   # Create a temporary build dir and make sure we clean it up. For
   # debugging, comment out the trap line.


### PR DESCRIPTION
Commit 2c4b4e74 set a umask of 277 which blocked the copy of the `openssl.cnf` file as the temp directory was created with no write permissions.  This breaks non-root execution of the script.

```bash
$ ./gen_cert.sh foo.com acme
cp: cannot create regular file '/tmp/ssl-egiQnl/site_selfsigned_openssl.cnf': Permission denied
$ ls -ld /tmp/ssl-egiQnl
dr-x------ 2 gdahlman gdahlman 4096 Jul  6 20:13 /tmp/ssl-egiQnl
```