### PR TITLE
Explain why windows unzip is complicated

### DIFF
--- a/packer/scripts/windows/install_windows_updates.ps1
+++ b/packer/scripts/windows/install_windows_updates.ps1
@@ -9,6 +9,9 @@ $filePath = "$($env:TEMP)\PSWindowsUpdate.zip"
 
 (New-Object System.Net.WebClient).DownloadFile($webDeployURL, $filePath)
 
+# Older versions of Powershell do not have 'Expand Archive'
+# Use Shell.Application custom object to unzip
+# https://stackoverflow.com/questions/27768303/how-to-unzip-a-file-in-powershell
 $shell = New-Object -ComObject Shell.Application
 $zipFile = $shell.NameSpace($filePath)
 $destinationFolder = $shell.NameSpace("C:\Program Files\WindowsPowerShell\Modules")


### PR DESCRIPTION
The current powershell module install doesn't work on windows 'core' edition. 

I tried to figure out why the script didn't just use 'Expand Archive' or 'Copy-Item' and instead used Custom ComObjects. 

Adds a comment explaining the reasoning behind using such a unusal but cleaver way to copy a file.